### PR TITLE
Feat: Add SMTP_FUNCTION toggle for auth workflows

### DIFF
--- a/auth/forgot_password.php
+++ b/auth/forgot_password.php
@@ -11,6 +11,7 @@ if (file_exists($baseDir . '/config.php')) {
 }
 
 $pageTitle = "Recuperar Contraseña";
+$smtp_enabled = (defined('SMTP_FUNCTION_STATUS') && SMTP_FUNCTION_STATUS === 'ON');
 
 // Mensajes de sesión para feedback
 $errors = $_SESSION['fp_errors'] ?? [];
@@ -56,32 +57,38 @@ unset($_SESSION['fp_form_data']);
                         <h3 class="text-center"><?php echo htmlspecialchars($pageTitle); ?></h3>
                     </div>
                     <div class="card-body">
-                        <p class="text-muted text-center">Ingresa tu dirección de correo electrónico y te enviaremos un enlace para restablecer tu contraseña.</p>
-
-                        <?php if (!empty($success_message)): ?>
-                            <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
-                        <?php endif; ?>
-
-                        <?php if (!empty($errors)): ?>
-                            <div class="alert alert-danger">
-                                <ul>
-                                    <?php foreach ($errors as $error): ?>
-                                        <li><?php echo htmlspecialchars($error); ?></li>
-                                    <?php endforeach; ?>
-                                </ul>
+                        <?php if (!$smtp_enabled): ?>
+                            <div class="alert alert-warning" role="alert">
+                                El sistema de recuperación de contraseña ha sido deshabilitado por el administrador del sistema.
                             </div>
-                        <?php endif; ?>
+                        <?php else: ?>
+                            <p class="text-muted text-center">Ingresa tu dirección de correo electrónico y te enviaremos un enlace para restablecer tu contraseña.</p>
 
-                        <?php if (empty($success_message)): // Solo mostrar el formulario si no hay mensaje de éxito ?>
-                        <form action="handle_forgot_password.php" method="POST">
-                            <div class="form-group">
-                                <label for="email">Correo Electrónico</label>
-                                <input type="email" class="form-control" id="email" name="email"
-                                       value="<?php echo htmlspecialchars($form_data['email'] ?? ''); ?>" required autofocus>
-                            </div>
-                            <button type="submit" class="btn btn-primary btn-block">Enviar Enlace de Recuperación</button>
-                        </form>
-                        <?php endif; ?>
+                            <?php if (!empty($success_message)): ?>
+                                <div class="alert alert-success"><?php echo htmlspecialchars($success_message); ?></div>
+                            <?php endif; ?>
+
+                            <?php if (!empty($errors)): ?>
+                                <div class="alert alert-danger">
+                                    <ul>
+                                        <?php foreach ($errors as $error): ?>
+                                            <li><?php echo htmlspecialchars($error); ?></li>
+                                        <?php endforeach; ?>
+                                    </ul>
+                                </div>
+                            <?php endif; ?>
+
+                            <?php if (empty($success_message)): // Solo mostrar el formulario si no hay mensaje de éxito y SMTP está habilitado ?>
+                            <form action="handle_forgot_password.php" method="POST">
+                                <div class="form-group">
+                                    <label for="email">Correo Electrónico</label>
+                                    <input type="email" class="form-control" id="email" name="email"
+                                           value="<?php echo htmlspecialchars($form_data['email'] ?? ''); ?>" required autofocus>
+                                </div>
+                                <button type="submit" class="btn btn-primary btn-block">Enviar Enlace de Recuperación</button>
+                            </form>
+                            <?php endif; ?>
+                        <?php endif; // Cierre del if $smtp_enabled ?>
                     </div>
                     <div class="card-footer text-center">
                         <small><a href="login.php">Volver a Iniciar Sesión</a></small>

--- a/auth/handle_forgot_password.php
+++ b/auth/handle_forgot_password.php
@@ -11,6 +11,17 @@ require_once $baseDir . '/helpers/email_sender.php'; // Para enviar el email de 
 $_SESSION['fp_errors'] = [];
 $_SESSION['fp_form_data'] = ['email' => $_POST['email'] ?? ''];
 
+// Leer el estado de SMTP_FUNCTION_STATUS de config.php
+$smtp_enabled = (defined('SMTP_FUNCTION_STATUS') && SMTP_FUNCTION_STATUS === 'ON');
+
+if (!$smtp_enabled) {
+    // Si SMTP está deshabilitado, no se debería poder llegar aquí si el formulario está oculto.
+    // Pero como defensa, establecemos un error y redirigimos.
+    $_SESSION['fp_errors'][] = "El sistema de recuperación de contraseña está deshabilitado.";
+    header('Location: forgot_password.php');
+    exit;
+}
+
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
     $email = trim($_POST['email'] ?? '');
 

--- a/auth/handle_reset_password.php
+++ b/auth/handle_reset_password.php
@@ -9,6 +9,19 @@ require_once $baseDir . '/includes/db_connection.php';
 
 $_SESSION['reset_errors'] = [];
 
+// Leer el estado de SMTP_FUNCTION_STATUS de config.php
+$smtp_enabled = (defined('SMTP_FUNCTION_STATUS') && SMTP_FUNCTION_STATUS === 'ON');
+
+if (!$smtp_enabled) {
+    // Si SMTP está deshabilitado, no procesar el reseteo.
+    // Esta situación no debería ocurrir si reset_password.php ya bloquea el formulario.
+    $_SESSION['reset_errors'][] = "El sistema de recuperación de contraseña está deshabilitado.";
+    // No hay un token GET para pasar aquí si el flujo es correcto,
+    // pero si alguien llega aquí manipulando, redirigir a forgot_password que mostrará el mensaje.
+    header('Location: forgot_password.php');
+    exit;
+}
+
 // El token debe estar en la sesión, puesto allí por reset_password.php
 if ($_SERVER["REQUEST_METHOD"] == "POST" && isset($_SESSION['reset_token'])) {
     $token = $_SESSION['reset_token'];

--- a/config-sample.php
+++ b/config-sample.php
@@ -23,6 +23,14 @@ date_default_timezone_set('America/Bogota'); // Ajusta a tu zona horaria
 // Para tokens y seguridad
 define('TOKEN_EXPIRATION_HOURS', 1); // Tiempo de expiración para tokens de recuperación en horas
 
+// Configuración de Funcionalidad SMTP (para activar/desactivar envío de emails y flujos dependientes)
+// Lee la variable de entorno 'SMTP_FUNCTION'. Si no está definida, usa 'ON' por defecto.
+// Valores posibles: 'ON' (funcionalidad de email activada), 'OFF' (funcionalidad de email desactivada)
+// Cuando está en 'OFF':
+//  - Registro crea usuarios activados directamente.
+//  - Recuperación de contraseña se deshabilita.
+define('SMTP_FUNCTION_STATUS', getenv('SMTP_FUNCTION') ?: 'ON');
+
 // Habilitar/Deshabilitar errores de PHP para desarrollo/producción
 // En desarrollo:
 ini_set('display_errors', 1);


### PR DESCRIPTION
Implemented a new configuration option `SMTP_FUNCTION_STATUS` (controlled by the `SMTP_FUNCTION` environment variable, defaults to 'ON').

This allows disabling email-dependent features:
- When 'OFF', user registration activates accounts directly without email.
- When 'OFF', password recovery funcionality is disabled, and relevant pages/handlers inform the user about this.

Files updated:
- `config-sample.php`: Added `SMTP_FUNCTION_STATUS` definition.
- `auth/handle_register.php`: Modified to activate users directly if SMTP is OFF.
- `auth/forgot_password.php`: Modified to display a "disabled" message if SMTP is OFF.
- `auth/handle_forgot_password.php`: Added check to prevent processing if SMTP is OFF.
- `auth/reset_password.php`: Added check to display "disabled" message if SMTP is OFF.
- `auth/handle_reset_password.php`: Added check to prevent processing if SMTP is OFF.

This change provides flexibility for environments where SMTP/email services are not available or desired for these specific functions.