### PR TITLE
Fix: Correct session start order to prevent warnings

### DIFF
--- a/auth/activate.php
+++ b/auth/activate.php
@@ -1,10 +1,8 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php'; // Para interactuar con la BD
 
 $pageTitle = "Activación de Cuenta";

--- a/auth/forgot_password.php
+++ b/auth/forgot_password.php
@@ -1,13 +1,13 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
 if (file_exists($baseDir . '/config.php')) {
-    require_once $baseDir . '/config.php';
+    require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 } else {
-    die('El archivo de configuración no se encuentra.');
+    // Si config.php no existe, es un error fatal.
+    // session_start(); // No tendría sentido iniciar sesión si la config base falla.
+    die('El archivo de configuración principal (config.php) no se encuentra. La aplicación no puede continuar.');
 }
 
 $pageTitle = "Recuperar Contraseña";

--- a/auth/handle_forgot_password.php
+++ b/auth/handle_forgot_password.php
@@ -1,10 +1,8 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php';
 require_once $baseDir . '/helpers/email_sender.php'; // Para enviar el email de recuperación
 

--- a/auth/handle_login.php
+++ b/auth/handle_login.php
@@ -1,10 +1,8 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php'; // Para interactuar con la BD
 
 $_SESSION['login_errors'] = [];

--- a/auth/handle_register.php
+++ b/auth/handle_register.php
@@ -1,17 +1,16 @@
 <?php
-// Iniciar sesión para poder usar variables de sesión para mensajes y datos de formulario
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 
 // Incluir archivos necesarios
 // __DIR__ es el directorio actual (auth), dirname(__DIR__) es el directorio raíz del proyecto.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php';
 require_once $baseDir . '/helpers/email_sender.php'; // Para enviar el email de activación
 
 // Inicializar arrays para errores y datos de formulario
+// Las variables de sesión ya deberían estar disponibles gracias a config.php
 $_SESSION['errors'] = [];
 $_SESSION['form_data'] = $_POST; // Guardar los datos del POST para repoblar el formulario si hay error
 

--- a/auth/handle_reset_password.php
+++ b/auth/handle_reset_password.php
@@ -1,10 +1,8 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php';
 
 $_SESSION['reset_errors'] = [];

--- a/auth/login.php
+++ b/auth/login.php
@@ -1,17 +1,19 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 
 // Incluir config.php para acceso a APP_URL, APP_NAME, etc.
 $baseDir = dirname(__DIR__);
 if (file_exists($baseDir . '/config.php')) {
-    require_once $baseDir . '/config.php';
+    require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 } else {
-    die('El archivo de configuración no se encuentra.');
+    // Si config.php no existe, es un error fatal.
+    // session_start(); // No tendría sentido iniciar sesión si la config base falla.
+    die('El archivo de configuración principal (config.php) no se encuentra. La aplicación no puede continuar.');
 }
 
 // Si el usuario ya está logueado, redirigirlo a la página principal/dashboard
+// La sesión ya debería estar iniciada por config.php
 if (isset($_SESSION['user_id'])) {
     header('Location: ' . APP_URL . '/index.php'); // Asumiendo que index.php es el dashboard
     exit;

--- a/auth/logout.php
+++ b/auth/logout.php
@@ -1,17 +1,18 @@
 <?php
-// Iniciar la sesión para poder destruirla.
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí explícitamente ANTES de incluir config.php,
+// pero sí necesitamos asegurarnos de que la sesión esté activa para poder destruirla.
+// config.php ya se encarga de iniciarla si no está activa.
 
 // Cargar la configuración para obtener APP_URL para la redirección.
-// Es una buena práctica tener una forma consistente de acceder a la raíz del proyecto.
 $baseDir = dirname(__DIR__);
 if (file_exists($baseDir . '/config.php')) {
-    require_once $baseDir . '/config.php';
+    require_once $baseDir . '/config.php'; // Esto asegura que la sesión está iniciada y configurada.
     $redirect_url = APP_URL . '/auth/login.php';
 } else {
     // Fallback si config.php no está disponible.
+    // Si config.php no está, es probable que APP_URL tampoco esté definido.
+    // Intentar iniciar una sesión aquí sería problemático sin las configuraciones.
     // Esto no debería suceder en una aplicación bien configurada.
     // Redirigir a una ruta relativa si APP_URL no está disponible.
     $redirect_url = 'login.php';

--- a/auth/register.php
+++ b/auth/register.php
@@ -1,21 +1,19 @@
 <?php
-// Incluir config.php al inicio para asegurar que las sesiones y otras configuraciones estén disponibles.
-// Es una buena práctica tener un archivo central de inicialización o configuración.
-if (file_exists('../config.php')) {
-    require_once '../config.php';
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
+$baseDir = dirname(__DIR__); // Raíz del proyecto
+if (file_exists($baseDir . '/config.php')) {
+    require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 } else {
-    die('El archivo de configuración no se encuentra. Por favor, copie config-sample.php a config.php y configurelo.');
+    // Si config.php no existe, es un error fatal.
+    die('El archivo de configuración principal (config.php) no se encuentra. La aplicación no puede continuar.');
 }
 
-// Incluir header temporalmente aquí, idealmente se gestionaría con un sistema de plantillas o includes más robusto.
-if (file_exists('../templates/header.php')) {
-    // Pasamos el título de la página al header
-    $pageTitle = "Registro de Usuario";
-    // Podríamos pasar otras variables si fueran necesarias para el header
-    // include '../templates/header.php';
-}
+// Título de la página para la plantilla/navegación
+$pageTitle = "Registro de Usuario";
 
 // Lógica para manejar mensajes (éxito o error) que podrían venir de handle_register.php
+// Las variables de sesión ya deberían estar disponibles gracias a config.php
 $errors = $_SESSION['errors'] ?? [];
 $success_message = $_SESSION['success_message'] ?? '';
 $form_data = $_SESSION['form_data'] ?? [];

--- a/auth/reset_password.php
+++ b/auth/reset_password.php
@@ -1,10 +1,8 @@
 <?php
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
+// config.php se encarga de iniciar la sesión después de configurar los parámetros.
+// No iniciar sesión aquí prematuramente.
 $baseDir = dirname(__DIR__);
-require_once $baseDir . '/config.php';
+require_once $baseDir . '/config.php'; // Esto ya debería iniciar la sesión si es necesario.
 require_once $baseDir . '/includes/db_connection.php';
 
 $pageTitle = "Restablecer Contraseña";

--- a/index.php
+++ b/index.php
@@ -1,16 +1,12 @@
 <?php
 // index.php (Pantalla Principal / Dashboard)
 
-// Iniciar sesión y cargar configuración primero
-if (session_status() == PHP_SESSION_NONE) {
-    session_start();
-}
-
-// Cargar configuración y funciones comunes
+// Cargar configuración. config.php se encarga de iniciar la sesión DESPUÉS de setear los parámetros.
 require_once __DIR__ . '/config.php';
 // require_once __DIR__ . '/includes/functions.php'; // Si tienes funciones helper adicionales
 
 // Verificar si el usuario está logueado. Si no, redirigir a login.php.
+// Ahora la sesión ya debería estar iniciada por config.php si no lo estaba.
 if (!isset($_SESSION['user_id'])) {
     header('Location: ' . APP_URL . '/auth/login.php');
     exit;


### PR DESCRIPTION
Moved all explicit session_start() calls to occur only at the end of config.php, after all session parameters (ini_set, session_set_cookie_params) have been configured.

Removed premature session_start() calls from:
- index.php
- auth/activate.php
- auth/forgot_password.php
- auth/handle_forgot_password.php
- auth/handle_login.php
- auth/handle_register.php
- auth/handle_reset_password.php
- auth/login.php
- auth/logout.php (ensured config.php is loaded first)
- auth/register.php
- auth/reset_password.php

This change aims to resolve PHP warnings about modifying session settings when a session is already active, particularly when session.auto_start=0.