### PR TITLE
Fix: Integrate PHPMailer via Composer and autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,11 @@
             "email": "tu_email@example.com"
         }
     ],
-    "require": {},
+    "require": {
+        "php": ">=7.3",
+        "vlucas/phpdotenv": "^5.0",
+        "phpmailer/phpmailer": "^6.5"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "src/"

--- a/helpers/email_sender.php
+++ b/helpers/email_sender.php
@@ -17,15 +17,12 @@ if (!defined('AWS_SES_HOST')) {
     }
 }
 
-// Cargar las clases de PHPMailer. Ajusta la ruta según la ubicación de tu carpeta vendor.
-// La estructura de PHPMailer a partir de v6 es vendor/phpmailer/phpmailer/src/
-$phpMailerBaseDir = dirname(__DIR__) . '/vendor/phpmailer/phpmailer/';
-require_once $phpMailerBaseDir . 'src/Exception.php';
-require_once $phpMailerBaseDir . 'src/PHPMailer.php';
-require_once $phpMailerBaseDir . 'src/SMTP.php';
+// No es necesario cargar manualmente las clases de PHPMailer si se usa el autoloader de Composer.
+// vendor/autoload.php (incluido en config.php) se encargará de esto.
+// Las sentencias `use` al principio del archivo son suficientes.
 
 /**
- * Envía un correo electrónico utilizando AWS SES a través de PHPMailer.
+ * Envía un correo electrónico utilizando AWS SES (u otro SMTP configurado) a través de PHPMailer.
  *
  * @param string $to Destinatario del correo.
  * @param string $subject Asunto del correo.


### PR DESCRIPTION
- Added phpmailer/phpmailer as a dependency in composer.json.
- Removed manual require_once calls for PHPMailer files in helpers/email_sender.php.
- The application now relies on Composer's autoloader for PHPMailer.

This change addresses the "Failed to open stream" error for PHPMailer files, assuming PHPMailer is correctly installed via `composer install` or `composer update`.